### PR TITLE
Provide a means for passing additional data to client on page load.

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const logger = require('morgan');
 const hbs = require('hbs');
 const hbsHelpers = require('./server/views/helpers');
 const csrfProtection = require('./server/middleware/csrf');
+const clientContext = require('./server/middleware/client-context');
 const { sessionMiddleware } = require('./server/middleware/session');
 const { userStatusLocals } = require('./server/middleware/auth');
 
@@ -22,15 +23,18 @@ app.initPromise = (async () => {
   hbs.localsAsTemplateData(app);
   hbsHelpers(hbs);
 
+  // App-level middleware stack
   app.use(logger('dev'));
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   app.use(cookieParser(process.env.COOKIE_SECRET));
   app.use(sessionMiddleware());
+  app.use(clientContext);
   app.use(passport.initialize());
   app.use(passport.session());
   app.use(userStatusLocals);
 
+  // Static files in public directory
   app.use(express.static(path.join(__dirname, 'client', 'public')));
 
   // Dev server init
@@ -48,6 +52,7 @@ app.initPromise = (async () => {
     }
   }
 
+  // Application routes (csrf protection not needed for static resources or vite dev server)
   app.use(csrfProtection);
   app.use('/', indexRouter);
 

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -2,9 +2,21 @@ const express = require('express');
 
 /** @type {import('express').RequestHandler} */
 function userStatusLocals(req, res, next) {
-  res.locals.user = req.user;
+  if (req.user) {
+    res.locals.user = Object.assign({}, req.user.dataValues);
+    delete res.locals.user.passwordHash;
+    delete res.locals.user.emailAddress;
+    delete res.locals.user.phoneNumber;
+    delete res.locals.user.balance;
+  }
+
   res.locals.isAuthenticated = req.isAuthenticated();
   res.locals.isUnauthenticated = req.isUnauthenticated();
+
+  if (req.isAuthenticated()) {
+    res.locals.clientContext.user = res.locals.user;
+  }
+
   next();
 }
 

--- a/server/middleware/client-context.js
+++ b/server/middleware/client-context.js
@@ -1,0 +1,4 @@
+module.exports = function (req, res, next) {
+  res.locals.clientContext = {};
+  next();
+};

--- a/server/views/helpers/index.js
+++ b/server/views/helpers/index.js
@@ -8,6 +8,6 @@ function registerHelperModule(hbs, helperModule) {
 }
 
 module.exports = function registerHelpers(hbs) {
-  registerHelperModule(hbs, helpers(['comparison']));
+  registerHelperModule(hbs, helpers(['comparison', 'object']));
   registerHelperModule(hbs, clientScriptHelpers);
 };

--- a/server/views/layout.hbs
+++ b/server/views/layout.hbs
@@ -14,6 +14,8 @@
     <script>
       window.context = JSON.parse(decodeHTMLEntities(document.querySelector('#application-context').textContent));
 
+      // Generally, you'd want to use a library's implementation of html entity decoding. This is just a quick-and-dirty way
+      // to get this working.
       function decodeHTMLEntities(str) {
         const txt = document.createElement('textarea');
         txt.innerHTML = str;

--- a/server/views/layout.hbs
+++ b/server/views/layout.hbs
@@ -10,6 +10,10 @@
     {{#isnt settings.env "production"}}
       <script type="module" src="http://localhost:{{settings.port}}/@vite/client"></script>
     {{/isnt}}
+    <script id="application-context" type="application/json">{{{JSONstringify clientContext}}}</script>
+    <script>
+      window.context = JSON.parse(document.querySelector('#application-context').textContent);
+    </script>
   </head>
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">

--- a/server/views/layout.hbs
+++ b/server/views/layout.hbs
@@ -10,9 +10,15 @@
     {{#isnt settings.env "production"}}
       <script type="module" src="http://localhost:{{settings.port}}/@vite/client"></script>
     {{/isnt}}
-    <script id="application-context" type="application/json">{{{JSONstringify clientContext}}}</script>
+    <script id="application-context" type="application/json">{{JSONstringify clientContext}}</script>
     <script>
-      window.context = JSON.parse(document.querySelector('#application-context').textContent);
+      window.context = JSON.parse(decodeHTMLEntities(document.querySelector('#application-context').textContent));
+
+      function decodeHTMLEntities(str) {
+        const txt = document.createElement('textarea');
+        txt.innerHTML = str;
+        return txt.value;
+      }
     </script>
   </head>
   <body>


### PR DESCRIPTION
This PR adds the ability to send additional data on page load by setting a value on res.locals.clientContext in the server-side route handler for the page. This data can then be accessed on the client side under window.context. If a user is logged in, some information, such as user ID and role, will be provided under window.context.user on the client side. This information is useful for conditionally rendering something based on the user role.

The addition of this client-side context does not change anything for auth checks on the server-side. res.locals.clientContext is intented to only be set from the server-side, not read. Anything the server needs can be found in req.user, req.session, or in the database.

This should help with making it so a profile can't be edited if it's not yours. Even if someone changes these values in their browser, since we also validate on the server-side, this won't open up any holes in case anyone is wondering.